### PR TITLE
AWS ERA5 download fix for Python<3.12

### DIFF
--- a/download_toolbox/data/aws.py
+++ b/download_toolbox/data/aws.py
@@ -508,7 +508,10 @@ class AWSDownloader(ThreadedDownloader):
             filtered_files = self.__list_matching_files(prefix, start_dt, end_dt,
                                 cmip6_variable_code, ecmwf_variable_code, bucket_name,
                                 multiple_levels=True if level else False)
-            logging.debug(f"Files to download:\n\t{'\n\t'.join(filtered_files[cmip6_variable_code])}")
+            joined_files = "\n\t".join(filtered_files[cmip6_variable_code])
+            logging.debug(f"Files to download:\n\t{joined_files}")
+
+
 
             download_path = os.path.join(var_config.root_path,
                                         self.dataset.location.name,

--- a/download_toolbox/interface.py
+++ b/download_toolbox/interface.py
@@ -12,6 +12,7 @@ from download_toolbox.time import Frequency
 from download_toolbox.utils import get_implementation
 
 from download_toolbox.data.amsr import AMSRDatasetConfig
+from download_toolbox.data.aws import AWSDatasetConfig
 from download_toolbox.data.cds import ERA5DatasetConfig
 from download_toolbox.data.esgf import CMIP6DatasetConfig
 from download_toolbox.data.osisaf import SICDatasetConfig
@@ -21,6 +22,7 @@ __all__ = [
     "DataCollection",
     "DatasetConfig",
     "AMSRDatasetConfig",
+    "AWSDatasetConfig",
     "ERA5DatasetConfig",
     "CMIP6DatasetConfig",
     "SICDatasetConfig",


### PR DESCRIPTION
Prevents following issue on Python<3.12:

```
$ download_aws --help
Traceback (most recent call last):
  File "/data/hpcdata/users/jambyr/miniforge3/envs/icenet4/bin/download_aws", line 5, in <module>
    from download_toolbox.data.aws import main
  File "/data/hpcdata/users/jambyr/icenet4/pipeline/src/download-toolbox/download_toolbox/data/aws.py", line 511
    logging.debug(f"Files to download:\n\t{'\n\t'.join(filtered_files[cmip6_variable_code])}")
                                                                                             ^
SyntaxError: f-string expression part cannot include a backslash
```

And, also, add AWSDatasetConfig to the interface.